### PR TITLE
Add acessibility support to nav tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ expands to
 </div>
 ```
 
+Also, custom attributes can added to the `ul`
+
+```slim
+= tabs nav_attributes: { 'aria-label': 'Accessibility' } do |c|
+  - c.tab 'Profile', anchor: 'profile', link_class: 'my-custom-class'
+  - c.tab 'New feature', anchor: 'new', active: true
+```
+expands to
+```html
+<ul class="nav nav-tabs" aria-label="Accessibility">
+    <li class="my-custom-class active">
+        <a data-toggle="tab" href="#profile">Profile</a>
+    </li>
+...
+```
+
 ## Bootstrap 4
 
 Default bootstrap version is 3. To use bootstrap 4 tabs add file to initializers
@@ -134,6 +150,21 @@ expands to
     ...
 </div>
 ```
+Also, custom attributes can added to the `nav` or `ul`
+
+```slim
+= tabs nav_attributes: { 'aria-label': 'Accessibility' } do |c|
+  - c.tab 'Profile', anchor: 'profile', link_class: 'my-custom-class'
+  - c.tab 'New feature', anchor: 'new', active: true
+```
+expands to
+```html
+<ul class="nav nav-tabs" aria-label="Accessibility">
+    <li class="nav-item">
+        <a data-toggle="tab" class="nav-link my-custom-class" href="#profile">Profile</a>
+    </li>
+...
+```
 
 ## Bootstrap 5
 
@@ -187,6 +218,20 @@ expands to
 <div class="tab-content my-padding">
     ...
 </div>
+```
+Also, custom attributes can added to the `nav` or `ul`
+
+```slim
+= tabs nav_attributes: { 'aria-label': 'Accessibility' } do |c|
+  - c.tab 'Profile', anchor: 'profile', link_class: 'my-custom-class'
+  - c.tab 'New feature', anchor: 'new', active: true
+```
+expands to
+```html
+<ul class="nav nav-tabs" role="tablist" aria-label="Accessibility"></ul>
+    <li class="nav-item" role="presentation">
+        <button name="button" type="submit" data-bs-toggle="tab" data-bs-target="#profile" class="nav-link my-custom-class" role="tab">Profile</button></li>
+...
 ```
 
 ## Configuration

--- a/lib/rails-bootstrap-tabs/renderers/tabs_bootstrap3_renderer.rb
+++ b/lib/rails-bootstrap-tabs/renderers/tabs_bootstrap3_renderer.rb
@@ -1,9 +1,9 @@
 module RailsBootstrapTabs::Renderers
   class TabsBootstrap3Renderer < TabsRenderer
-    def render_tabs_wrapper
-      content_tag :ul, class: 'nav nav-tabs' do
-        yield
-      end
+    def render_tabs_wrapper(&block)
+      tag_attributes = { class: 'nav nav-tabs' }
+      tag_attributes.merge!(@options[:nav_attributes]) if @options[:nav_attributes]
+      content_tag :ul, tag_attributes, &block
     end
 
     def render_tab(tab)

--- a/lib/rails-bootstrap-tabs/renderers/tabs_bootstrap4_renderer.rb
+++ b/lib/rails-bootstrap-tabs/renderers/tabs_bootstrap4_renderer.rb
@@ -1,15 +1,9 @@
 module RailsBootstrapTabs::Renderers
   class TabsBootstrap4Renderer < TabsRenderer
-    def render_tabs_wrapper
-      if @options[:nav_markup]
-        content_tag :nav, class: 'nav nav-tabs' do
-          yield
-        end
-      else
-        content_tag :ul, class: 'nav nav-tabs' do
-          yield
-        end
-      end
+    def render_tabs_wrapper(&block)
+      tag_attributes = { class: 'nav nav-tabs' }
+      tag_attributes.merge!(@options[:nav_attributes]) if @options[:nav_attributes]
+      content_tag (@options[:nav_markup] ? :nav : :ul), tag_attributes, &block
     end
 
     def render_tab(tab)

--- a/lib/rails-bootstrap-tabs/renderers/tabs_bootstrap5_renderer.rb
+++ b/lib/rails-bootstrap-tabs/renderers/tabs_bootstrap5_renderer.rb
@@ -1,16 +1,15 @@
 module RailsBootstrapTabs::Renderers
   class TabsBootstrap5Renderer < TabsRenderer
-    def render_tabs_wrapper
+    def render_tabs_wrapper(&block)
+      tag_attributes = { class: 'nav nav-tabs', role: 'tablist' }
+      tag_attributes.merge!(@options[:nav_attributes]) if @options[:nav_attributes]
+
       if @options[:nav_markup]
         content_tag :nav do
-          content_tag :div, class: 'nav nav-tabs', role: 'tablist' do
-            yield
-          end
+          content_tag :div, tag_attributes, &block
         end
       else
-        content_tag :ul, class: 'nav nav-tabs', role: 'tablist' do
-          yield
-        end
+        content_tag :ul, tag_attributes, &block
       end
     end
 

--- a/lib/rails-bootstrap-tabs/version.rb
+++ b/lib/rails-bootstrap-tabs/version.rb
@@ -1,3 +1,3 @@
 module RailsBootstrapTabs
-  VERSION = '0.3.3'.freeze
+  VERSION = '0.3.4'.freeze
 end

--- a/lib/rails-bootstrap-tabs/version.rb
+++ b/lib/rails-bootstrap-tabs/version.rb
@@ -1,3 +1,3 @@
 module RailsBootstrapTabs
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.3.3'.freeze
 end

--- a/spec/renderers/tabs_bootstrap3_renderer_spec.rb
+++ b/spec/renderers/tabs_bootstrap3_renderer_spec.rb
@@ -4,11 +4,12 @@ require 'rails-bootstrap-tabs'
 
 describe RailsBootstrapTabs::Renderers::TabsBootstrap3Renderer do
   let(:template) { mock_template }
-  let(:renderer) { RailsBootstrapTabs::Renderers::TabsBootstrap3Renderer.new(template) }
+  let(:args) { { nav_attributes: { 'aria-label': 'Accessibility' } } }
+  let(:renderer) { RailsBootstrapTabs::Renderers::TabsBootstrap3Renderer.new(template, args) }
 
   describe '#render_tabs_wrapper' do
     it 'renders wrapper' do
-      expect(renderer.render_tabs_wrapper { '[tabs_content]' }).to eq '<ul class="nav nav-tabs">[tabs_content]</ul>'
+      expect(renderer.render_tabs_wrapper { '[tabs_content]' }).to eq '<ul class="nav nav-tabs" aria-label="Accessibility">[tabs_content]</ul>'
     end
   end
 

--- a/spec/renderers/tabs_bootstrap4_renderer_spec.rb
+++ b/spec/renderers/tabs_bootstrap4_renderer_spec.rb
@@ -4,20 +4,22 @@ require 'rails-bootstrap-tabs'
 
 describe RailsBootstrapTabs::Renderers::TabsBootstrap4Renderer do
   let(:template) { mock_template }
-  let(:renderer) { RailsBootstrapTabs::Renderers::TabsBootstrap4Renderer.new(template) }
+  let(:args) { { nav_attributes: { 'aria-label': 'Accessibility' } } }
+  let(:renderer) { RailsBootstrapTabs::Renderers::TabsBootstrap4Renderer.new(template, args) }
 
   describe '#render_tabs_wrapper' do
     context 'wrapper_markup is nav' do
-      let(:renderer) { RailsBootstrapTabs::Renderers::TabsBootstrap4Renderer.new(template, { nav_markup: true } ) }
+      let(:args) { { nav_markup: true, nav_attributes: { 'aria-label': 'Accessibility' } } }
+      let(:renderer) { RailsBootstrapTabs::Renderers::TabsBootstrap4Renderer.new(template, args) }
 
       it 'renders nav wrapper' do
-        expect(renderer.render_tabs_wrapper { '[tabs_content]' }).to eq '<nav class="nav nav-tabs">[tabs_content]</nav>'
+        expect(renderer.render_tabs_wrapper { '[tabs_content]' }).to eq '<nav class="nav nav-tabs" aria-label="Accessibility">[tabs_content]</nav>'
       end
     end
 
     context 'wrapper_markup is NOT nav' do
       it 'renders ul wrapper' do
-        expect(renderer.render_tabs_wrapper { '[tabs_content]' }).to eq '<ul class="nav nav-tabs">[tabs_content]</ul>'
+        expect(renderer.render_tabs_wrapper { '[tabs_content]' }).to eq '<ul class="nav nav-tabs" aria-label="Accessibility">[tabs_content]</ul>'
       end
     end
   end

--- a/spec/renderers/tabs_bootstrap5_renderer_spec.rb
+++ b/spec/renderers/tabs_bootstrap5_renderer_spec.rb
@@ -4,20 +4,22 @@ require 'rails-bootstrap-tabs'
 
 describe RailsBootstrapTabs::Renderers::TabsBootstrap5Renderer do
   let(:template) { mock_template }
-  let(:renderer) { RailsBootstrapTabs::Renderers::TabsBootstrap5Renderer.new(template) }
+  let(:args) { { nav_attributes: { 'aria-label': 'Accessibility' } } }
+  let(:renderer) { RailsBootstrapTabs::Renderers::TabsBootstrap5Renderer.new(template, args) }
 
   describe '#render_tabs_wrapper' do
     context 'wrapper_markup is nav' do
-      let(:renderer) { RailsBootstrapTabs::Renderers::TabsBootstrap5Renderer.new(template, { nav_markup: true } ) }
+      let(:args) { { nav_markup: true, nav_attributes: { 'aria-label': 'Accessibility' } } }
+      let(:renderer) { RailsBootstrapTabs::Renderers::TabsBootstrap5Renderer.new(template, args) }
 
       it 'renders nav wrapper' do
-        expect(renderer.render_tabs_wrapper { '[tabs_content]' }).to eq '<nav><div class="nav nav-tabs" role="tablist">[tabs_content]</div></nav>'
+        expect(renderer.render_tabs_wrapper { '[tabs_content]' }).to eq '<nav><div class="nav nav-tabs" role="tablist" aria-label="Accessibility">[tabs_content]</div></nav>'
       end
     end
 
     context 'wrapper_markup is NOT nav' do
       it 'renders ul wrapper' do
-        expect(renderer.render_tabs_wrapper { '[tabs_content]' }).to eq '<ul class="nav nav-tabs" role="tablist">[tabs_content]</ul>'
+        expect(renderer.render_tabs_wrapper { '[tabs_content]' }).to eq '<ul class="nav nav-tabs" role="tablist" aria-label="Accessibility">[tabs_content]</ul>'
       end
     end
   end


### PR DESCRIPTION
Hi,

This addition is needed to provide accessibility compliance.

I added support to pass attributes to the nav element keeping the defaults for compatibility. In a nutshell, screen readers should be able to announce the tabs as navigation landmarks and need extra attributes.